### PR TITLE
fix: prevent freeze on large coordinates (goto), add input validation and README note [closes #4]

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ CLI tool for finding cat coordinates (native only, not WASM)
 
 ## Usage
 
+### Coordinate Limits & Stability
+
+- The `goto X Y` command in the terminal is limited to coordinates between -1,000,000 and +1,000,000 to prevent browser freezes and excessive resource usage. If you enter values outside this range, you will receive an error message and the app will remain stable.
+- This fixes a previous bug ([Issue #4](https://github.com/Suncompute/EndlessUtopia/issues/4)) where extremely large coordinates could freeze the web interface.
+
 ### WASM Application (Browser)
 
 Build and run the interactive web application:

--- a/src/app.rs
+++ b/src/app.rs
@@ -895,12 +895,15 @@ impl App {
             "goto" => {
                 if parts.len() >= 3 {
                     if let (Ok(x), Ok(y)) = (parts[1].parse::<f64>(), parts[2].parse::<f64>()) {
-                        if x.is_finite() && y.is_finite() {
+                        let max_coord = 1_000_000.0;
+                        if !x.is_finite() || !y.is_finite() {
+                            self.terminal_output.push("error: invalid coordinates".to_string());
+                        } else if x.abs() > max_coord || y.abs() > max_coord {
+                            self.terminal_output.push(format!("error: coordinates out of bounds (must be between -{} and +{})", max_coord, max_coord));
+                        } else {
                             self.offset_x = x;
                             self.offset_y = y;
                             self.terminal_output.push(format!("teleported to ({}, {})", x, y));
-                        } else {
-                            self.terminal_output.push("error: invalid coordinates".to_string());
                         }
                     } else {
                         self.terminal_output.push("error: invalid numbers".to_string());


### PR DESCRIPTION
- Adds input validation for the `goto X Y` command in the terminal, limiting coordinates to ±1,000,000.
- Prevents browser freeze and resource exhaustion when entering extremely large coordinates.
- Adds a note to the README about coordinate limits and stability.
- Closes #4.